### PR TITLE
Change class "page-date" to "post-date"

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 
 <article class="post">
   <h1 class="post-title">{{ page.title }}</h1>
-  <time datetime="{{ page.date | date_to_xmlschema }}" class="page-date">{{ page.date | date_to_string }}</time>
+  <time datetime="{{ page.date | date_to_xmlschema }}" class="post-date">{{ page.date | date_to_string }}</time>
   {{ content }}
 </article>
 


### PR DESCRIPTION
This resolves the issue where, on the home page, dates are formatted like this:

![image](https://cloud.githubusercontent.com/assets/1789800/6550273/de8fb2de-c5e0-11e4-84e3-1c7c2c65f81e.png)

but, on individual post pages, they're formatted like this:

![image](https://cloud.githubusercontent.com/assets/1789800/6550274/ea264e50-c5e0-11e4-9ded-b6ca3caf2237.png)
